### PR TITLE
Format rule dates with full month names

### DIFF
--- a/client/src/components/ScheduleRulesTable/index.tsx
+++ b/client/src/components/ScheduleRulesTable/index.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useEffect } from 'react';
-import { parseISO, parse, format } from 'date-fns';
+import { formatFriendlyDate } from '../../utils/dateUtils';
 import { useShiftContext } from '../../context/ShiftContext';
 import { useRules } from '../../context/RulesContext';
 import { usePersonnelData } from '../../context/PersonnelDataContext';
@@ -125,21 +125,6 @@ const formatBlockedShifts = (blockedShifts: { [shiftId: string]: { blockedDays: 
     .join(', ');
 };
 
-const parseDate = (dateStr: string) => {
-  if (dateStr.includes('-')) {
-    return parseISO(dateStr);
-  }
-  if (dateStr.includes('/')) {
-    return parse(dateStr, 'MM/dd/yyyy', new Date());
-  }
-  return new Date(dateStr);
-};
-
-const formatDateFriendly = (dateStr: string) => {
-  const date = parseDate(dateStr);
-  if (isNaN(date.getTime())) return dateStr;
-  return format(date, 'd/MMMM/yyyy');
-};
 
 const ScheduleRulesTable: React.FC = () => {
   const { shifts } = useShiftContext();
@@ -249,13 +234,13 @@ const ScheduleRulesTable: React.FC = () => {
               <tr>
                 <td className="border px-4 py-2">Start Date</td>
                 <td className="border px-4 py-2">
-                  {formatDateFriendly(rules.startDate)}
+                {formatFriendlyDate(rules.startDate)}
                 </td>
               </tr>
               <tr>
                 <td className="border px-4 py-2">End Date</td>
                 <td className="border px-4 py-2">
-                {formatDateFriendly(rules.endDate)}
+                {formatFriendlyDate(rules.endDate)}
                 </td>
               </tr>
               <tr>

--- a/client/src/utils/dateUtils.ts
+++ b/client/src/utils/dateUtils.ts
@@ -1,0 +1,17 @@
+import { parse, parseISO, format } from 'date-fns';
+
+/**
+ * Parse a date string in either ISO (yyyy-MM-dd) or US format (MM/dd/yyyy)
+ * and return a formatted string in day/monthName/year format, e.g. 2/June/2025.
+ */
+export function formatFriendlyDate(dateStr: string): string {
+  let date: Date;
+  if (dateStr.includes('-')) {
+    date = parseISO(dateStr);
+  } else if (dateStr.includes('/')) {
+    date = parse(dateStr, 'MM/dd/yyyy', new Date());
+  } else {
+    date = new Date(dateStr);
+  }
+  return isNaN(date.getTime()) ? dateStr : format(date, 'd/MMMM/yyyy');
+}


### PR DESCRIPTION
## Summary
- create `formatFriendlyDate` helper for parsing and formatting dates
- use helper in `ScheduleRulesTable` to show dates like `2/June/2025`

## Testing
- `npm run test:run`

------
https://chatgpt.com/codex/tasks/task_e_6846f760a748832e80a384b247e3a35a